### PR TITLE
Updates from lots of live testing edge cases.  Go to RC2.

### DIFF
--- a/docs/usage-instructions-v2.md
+++ b/docs/usage-instructions-v2.md
@@ -160,24 +160,27 @@ as in these examples:
 
 ```python
 from umapi_client import IdentityTypes
+user0 = UserAction(id_type=IdentityTypes.federatedID, email="someone@somecompany.com")
 user1 = UserAction(id_type=IdentityTypes.adobeID, email="user@isp.net")
 user2 = UserAction(id_type=IdentityTypes.enterpriseID, email="user@company.com")
 ```
 
-But when Federated ID is being used, and a non-email username is being
+When Federated ID is being used, and a non-email username is being
 used to identify users across the SAML connection, both the username
-and the domain must be specified separately, as in these examples:
+and the domain must be specified, as in these examples:
 
 ```python
-user3 = UserAction(id_type=IdentityTypes.federatedID,
+user3 = UserAction(id_type="federatedID",
                    username="user347", domain="division.conglomerate.com")
-user4 = UserAction(id_type=IdentityTypes.federatedID,
+user4 = UserAction(id_type="federatedID",
                    username="user348", domain="division.conglomerate.com",
                    email="john.r.user@conglomerate.com")
 ```
 
+As these examples show, you can supply the `id_type` as a string, if desired.
+
 Note that, as in the last example, it's OK to specify the email when
-creating a user object even if the email is not the unique ID or
+creating a Federated ID user object even if the email is not the unique ID or
 doesn't use the same domain.  If
 you later perform an operations on a user which requires the email
 (such as user creation on the Adobe side), the email will be remembered

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@
 from setuptools import setup, find_packages
 
 setup(name='umapi-client',
-      version='2.0rc1',
+      version='2.0rc2',
       description='Client for the User Management API (UMAPI) from Adobe - see https://adobe.ly/2h1pHgV',
       long_description=('The User Management API (aka the UMAPI) is an Adobe-hosted network service '
                         'which provides Adobe Enterprise customers the ability to manage their users.  This '

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -24,6 +24,11 @@ from umapi_client import IdentityTypes
 from umapi_client import UserAction
 
 
+def test_user_emptyid():
+    with pytest.raises(ValueError):
+        user = UserAction(id_type=IdentityTypes.federatedID)
+
+
 def test_user_adobeid():
     user = UserAction(email="dbrotsky@adobe.com")
     assert user.wire_dict() == {"do": [], "user": "dbrotsky@adobe.com"}
@@ -89,8 +94,19 @@ def test_create_user_federatedid_username():
                                 "user": "dbrotsky", "domain": "k.on-the-side.net"}
 
 
+def test_create_user_federatedid_username_email():
+    user = UserAction(id_type=IdentityTypes.federatedID,username="dbrotsky", domain="k.on-the-side.net",
+                      email="dbrotsky@k.on-the-side.net")
+    user.create(first_name="Daniel", last_name="Brotsky", country="US")
+    assert user.wire_dict() == {"do": [{"createFederatedID": {"email": "dbrotsky@k.on-the-side.net",
+                                                              "firstName": "Daniel", "lastName": "Brotsky",
+                                                              "country": "US"}}],
+                                "user": "dbrotsky", "domain": "k.on-the-side.net"}
+
+
 def test_create_user_federatedid_username_mismatch():
-    user = UserAction(id_type=IdentityTypes.federatedID, username="dbrotsky", domain="k.on-the-side.net")
+    user = UserAction(id_type=IdentityTypes.federatedID, username="dbrotsky", domain="k.on-the-side.net",
+                      email="foo@bar.net")
     with pytest.raises(ValueError):
         user.create(first_name="Daniel", last_name="Brotsky", country="US", email="foo@bar.com")
 
@@ -130,7 +146,7 @@ def test_remove_product_federatedid():
 
 
 def test_remove_product_federatedid_all():
-    user = UserAction(id_type=IdentityTypes.federatedID, email="dbrotsky@k.on-the-side.net")
+    user = UserAction(id_type='federatedID', email="dbrotsky@k.on-the-side.net")
     user.remove_group(all_groups=True)
     assert user.wire_dict() == {"do": [{"remove": "all"}],
                                 "user": "dbrotsky@k.on-the-side.net"}
@@ -144,7 +160,7 @@ def test_add_role_enterpriseid():
 
 
 def test_remove_role_enterpriseid():
-    user = UserAction(id_type=IdentityTypes.enterpriseID, email="dbrotsky@o.on-the-side.net")
+    user = UserAction(id_type='enterpriseID', email="dbrotsky@o.on-the-side.net")
     user.remove_role(groups=["Photoshop", "Illustrator"])
     assert user.wire_dict() == {"do": [{"removeRoles": {"admin": ["Photoshop", "Illustrator"]}}],
                                 "user": "dbrotsky@o.on-the-side.net"}
@@ -158,7 +174,7 @@ def test_remove_from_organization_federatedid():
 
 
 def test_remove_from_organization_adobeid():
-    user = UserAction(id_type=IdentityTypes.adobeID, email="dbrotsky@adobe.com")
+    user = UserAction(id_type='adobeID', email="dbrotsky@adobe.com")
     user.remove_from_organization()
     assert user.wire_dict() == {"do": [{"removeFromOrg": {}}],
                                 "user": "dbrotsky@adobe.com"}


### PR DESCRIPTION
* In anticipation of multiple domains per IdP, don't enforce super-tight domain restrictions.
* Allow the use of strings to specify identity types and option settings, rather than just enums.
* Be careful about which types of identity support username != email, and enforce username formats appropriately.
* Modularize validations in the UserAction class to produce better consistency.