### PR TITLE
Fix #44: UsersQuery should only return direct group memberships.

### DIFF
--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -327,7 +327,7 @@ class UsersQuery(QueryMultiple):
     Query for users meeting (optional) criteria
     """
 
-    def __init__(self, connection, in_group="", in_domain="", identity_type=""):
+    def __init__(self, connection, in_group="", in_domain="", identity_type="", direct_only=True):
         """
         Create a query for all users, or for those in a group or domain or both
         :param connection: Connection to run the query against
@@ -338,6 +338,7 @@ class UsersQuery(QueryMultiple):
         params = {}
         if in_domain: params["domain"] = in_domain
         if identity_type: params["type"] = identity_type
+        params["directOnly"] = direct_only
         QueryMultiple.__init__(self, connection=connection, object_type="user", url_params=groups, query_params=params)
 
 


### PR DESCRIPTION
* Add a direct_only parameter to UsersQuery, defaulted to true.
* Update tests to check behavior.
* Update version number and history to prepare for 2.5 release.