### PR TITLE
Feature/large group assignment

### DIFF
--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -330,32 +330,6 @@ def test_group_size_limit():
         assert conn.execute_single(user, immediate=True) == (0, 3, 3)
 
 
-def test_complex_group_split():
-    """
-    Test a complex command with add and remove directive, with multiple group types
-    UserAction's interface doesn't support this, so we build our own command array
-    :return:
-    """
-    group_prefix = "G"
-    add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
-    add_products = [group_prefix+six.text_type(n+1) for n in range(0, 26)]
-    remove_groups = [group_prefix+six.text_type(n+1) for n in range(0, 75)]
-    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
-    user.commands = [{
-        "add": {
-            GroupTypes.usergroup.name: add_groups,
-            GroupTypes.product.name: add_products,
-        },
-        "remove": {
-            GroupTypes.usergroup.name: remove_groups
-        }
-    }]
-    assert user.maybe_split_groups(10) is True
-    assert len(user.commands) == 15
-    assert GroupTypes.product.name not in user.commands[3]['add']
-    assert 'remove' not in user.commands[8]
-
-
 def test_split_add_user():
     """
     Make sure split doesn't do anything when we have a non-add/remove group action

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -337,7 +337,16 @@ def test_split_add_user():
     """
     user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
     user.create(first_name="Example", last_name="User", country="US", email="user@example.com")
+    user.update(first_name="EXAMPLE")
     assert user.maybe_split_groups(10) is False
+    assert len(user.commands) == 2
+    assert user.wire_dict() == {'do': [{'createEnterpriseID': {'country': 'US',
+                                                               'email': 'user@example.com',
+                                                               'firstname': 'Example',
+                                                               'lastname': 'User',
+                                                               'option': 'ignoreIfAlreadyExists'}},
+                                       {'update': {'firstname': 'EXAMPLE'}}],
+                                'user': 'user@example.com'}
 
 
 def test_split_role_assignment():

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -337,7 +337,7 @@ def test_complex_group_split():
     """
     group_prefix = "G"
     add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
-    add_products = [group_prefix+six.text_type(n+1) for n in range(0, 6)]
+    add_products = [group_prefix+six.text_type(n+1) for n in range(0, 26)]
     remove_groups = [group_prefix+six.text_type(n+1) for n in range(0, 75)]
     user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
     user.commands = [{
@@ -351,5 +351,5 @@ def test_complex_group_split():
     }]
     assert user.maybe_split_groups(10) is True
     assert len(user.commands) == 15
-    assert GroupTypes.product.name not in user.commands[1]['add']
+    assert GroupTypes.product.name not in user.commands[3]['add']
     assert 'remove' not in user.commands[8]

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -21,12 +21,13 @@
 import time
 from email.utils import formatdate
 
+import six
 import mock
 import pytest
 import requests
 
 from conftest import mock_connection_params, MockResponse
-from umapi_client import Connection, UnavailableError, ServerError, RequestError
+from umapi_client import Connection, UnavailableError, ServerError, RequestError, UserAction, GroupTypes, IdentityTypes
 from umapi_client import __version__ as umapi_version
 
 
@@ -242,3 +243,76 @@ def test_post_request_fail():
         mock_post.return_value = MockResponse(400, text="400 test request failure")
         conn = Connection(**mock_connection_params)
         pytest.raises(RequestError, conn.make_call, "", "[3, 5]")
+
+
+def test_large_group_assignment_split():
+    """
+    Ensure that large group list can be split into multiple commands
+    :return:
+    """
+    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+    user.add_to_groups(groups=["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10", "G11",
+                               "G12", "G13", "G14", "G15"], group_type=GroupTypes.usergroup)
+    user.split_groups(0, "add", GroupTypes.usergroup.name, 10)
+    assert len(user.commands) == 2
+    assert user.commands[0]["add"][GroupTypes.usergroup.name] == \
+           ["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10"]
+    assert user.commands[1]["add"][GroupTypes.usergroup.name] == \
+           ["G11", "G12", "G13", "G14", "G15"]
+
+
+def test_large_group_mix_split():
+    """
+    Ensure that group split works on add and remove
+    Each "add" and "remove" group should be split into 2 groups each
+    :return:
+    """
+    group_prefix = "G"
+    add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 15)]
+    remove_groups = [group_prefix+six.text_type(n+1) for n in range(15, 30)]
+    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+    user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup) \
+        .remove_from_groups(groups=remove_groups, group_type=GroupTypes.usergroup)
+    user.split_groups(0, "add", GroupTypes.usergroup.name, 10)
+    user.split_groups(1, "remove", GroupTypes.usergroup.name, 10)
+    assert len(user.commands) == 4
+    assert user.commands[0]["add"][GroupTypes.usergroup.name] == add_groups[0:10]
+    assert user.commands[1]["remove"][GroupTypes.usergroup.name] == remove_groups[0:10]
+    assert user.commands[2]["add"][GroupTypes.usergroup.name] == add_groups[10:]
+    assert user.commands[3]["remove"][GroupTypes.usergroup.name] == remove_groups[10:]
+
+
+def test_large_group_action_split():
+    """
+    Ensure that very large group lists (100+) will be handled appropriately
+    Connection.execute_multiple splits commands and splits actions
+    Result should be 2 actions, even though we only created one action
+    :return:
+    """
+    with mock.patch("umapi_client.connection.requests.Session.post") as mock_post:
+        mock_post.return_value = MockResponse(200, {"result": "success"})
+        conn = Connection(**mock_connection_params)
+
+        group_prefix = "G"
+        add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
+        user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+        user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
+        assert conn.execute_single(user, immediate=True) == (0, 2, 2)
+
+
+def test_group_size_limit():
+    """
+    Test with different 'throttle_groups' value, which governs the max size of the group list before commands are split
+    :return:
+    """
+    with mock.patch("umapi_client.connection.requests.Session.post") as mock_post:
+        mock_post.return_value = MockResponse(200, {"result": "success"})
+        params = mock_connection_params
+        params['throttle_groups'] = 5
+        conn = Connection(**params)
+
+        group_prefix = "G"
+        add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
+        user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+        user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
+        assert conn.execute_single(user, immediate=True) == (0, 3, 3)

--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -347,3 +347,16 @@ def test_split_role_assignment():
     user.add_role(groups=add_groups, role_type=RoleTypes.admin)
     assert user.maybe_split_groups(10) is True
     assert len(user.commands) == 3
+
+
+def test_no_group_split():
+    """
+    maybe_split should return false if nothing was split
+    :return:
+    """
+    group_prefix = "G"
+    add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 5)]
+    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+    user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
+    assert user.maybe_split_groups(10) is False
+    assert len(user.commands) == 1

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,7 +23,7 @@
 import pytest
 import six
 
-from conftest import mock_connection_params, MockResponse
+from conftest import mock_connection_params
 from umapi_client import ArgumentError
 from umapi_client import Connection
 from umapi_client import IdentityTypes, GroupTypes, RoleTypes

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -488,3 +488,21 @@ def test_large_group_action_split():
         user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
         user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
         assert conn.execute_single(user, immediate=True) == (0, 2, 2)
+
+
+def test_group_size_limit():
+    """
+    Test with different 'throttle_groups' value, which governs the max size of the group list before commands are split
+    :return:
+    """
+    with mock.patch("umapi_client.connection.requests.Session.post") as mock_post:
+        mock_post.return_value = MockResponse(200, {"result": "success"})
+        params = mock_connection_params
+        params['throttle_groups'] = 5
+        conn = Connection(**params)
+
+        group_prefix = "G"
+        add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
+        user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+        user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
+        assert conn.execute_single(user, immediate=True) == (0, 3, 3)

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,7 +23,7 @@
 import pytest
 import six
 
-from conftest import mock_connection_params
+from conftest import mock_connection_params, MockResponse
 from umapi_client import ArgumentError
 from umapi_client import Connection
 from umapi_client import IdentityTypes, GroupTypes, RoleTypes
@@ -432,3 +432,15 @@ def test_query_users():
     query = UsersQuery(conn, in_group="test", in_domain="test.com", direct_only=False)
     assert query.url_params == ["test"]
     assert query.query_params == {"directOnly": False, "domain": "test.com"}
+
+
+def test_large_group_assignment():
+    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+    user.add_to_groups(groups=["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10", "G11",
+                               "G12", "G13", "G14", "G15"], group_type=GroupTypes.usergroup)
+    user.split_groups(0, "add", GroupTypes.usergroup.name, 10)
+    assert len(user.commands) == 2
+    assert user.commands[0]["add"][GroupTypes.usergroup.name] == \
+           ["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10"]
+    assert user.commands[1]["add"][GroupTypes.usergroup.name] == \
+           ["G11", "G12", "G13", "G14", "G15"]

--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -23,6 +23,7 @@
 import pytest
 import six
 
+import mock
 from conftest import mock_connection_params, MockResponse
 from umapi_client import ArgumentError
 from umapi_client import Connection
@@ -434,7 +435,11 @@ def test_query_users():
     assert query.query_params == {"directOnly": False, "domain": "test.com"}
 
 
-def test_large_group_assignment():
+def test_large_group_assignment_split():
+    """
+    Ensure that large group list can be split into multiple commands
+    :return:
+    """
     user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
     user.add_to_groups(groups=["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10", "G11",
                                "G12", "G13", "G14", "G15"], group_type=GroupTypes.usergroup)
@@ -444,3 +449,42 @@ def test_large_group_assignment():
            ["G1", "G2", "G3", "G4", "G5", "G6", "G7", "G8", "G9", "G10"]
     assert user.commands[1]["add"][GroupTypes.usergroup.name] == \
            ["G11", "G12", "G13", "G14", "G15"]
+
+
+def test_large_group_mix_split():
+    """
+    Ensure that group split works on add and remove
+    Each "add" and "remove" group should be split into 2 groups each
+    :return:
+    """
+    group_prefix = "G"
+    add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 15)]
+    remove_groups = [group_prefix+six.text_type(n+1) for n in range(15, 30)]
+    user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+    user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)\
+        .remove_from_groups(groups=remove_groups, group_type=GroupTypes.usergroup)
+    user.split_groups(0, "add", GroupTypes.usergroup.name, 10)
+    user.split_groups(1, "remove", GroupTypes.usergroup.name, 10)
+    assert len(user.commands) == 4
+    assert user.commands[0]["add"][GroupTypes.usergroup.name] == add_groups[0:10]
+    assert user.commands[1]["remove"][GroupTypes.usergroup.name] == remove_groups[0:10]
+    assert user.commands[2]["add"][GroupTypes.usergroup.name] == add_groups[10:]
+    assert user.commands[3]["remove"][GroupTypes.usergroup.name] == remove_groups[10:]
+
+
+def test_large_group_action_split():
+    """
+    Ensure that very large group lists (100+) will be handled appropriately
+    Connection.execute_multiple splits commands and splits actions
+    Result should be 2 actions, even though we only created one action
+    :return:
+    """
+    with mock.patch("umapi_client.connection.requests.Session.post") as mock_post:
+        mock_post.return_value = MockResponse(200, {"result": "success"})
+        conn = Connection(**mock_connection_params)
+
+        group_prefix = "G"
+        add_groups = [group_prefix+six.text_type(n+1) for n in range(0, 150)]
+        user = UserAction(id_type=IdentityTypes.enterpriseID, email="user@example.com")
+        user.add_to_groups(groups=add_groups, group_type=GroupTypes.usergroup)
+        assert conn.execute_single(user, immediate=True) == (0, 2, 2)

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -314,33 +314,31 @@ class UserAction(Action):
         :param max_groups: Max group list size
         :return: True if at least one command was split, False if none were split
         """
-        new_commands = []
+        split_commands = []
         # return True if we split at least once
         maybe_split = False
         valid_step_keys = ['add', 'addRoles', 'remove']
         for command in self.commands:
             # commands are assumed to contain a single key
             step_key, step_args = next(six.iteritems(command))
-            if step_key not in valid_step_keys:
-                new_commands.append(command)
+            if step_key not in valid_step_keys or not isinstance(step_args, dict):
+                split_commands.append(command)
                 continue
-            split_commands = [command]
+            new_commands = [command]
             while True:
                 new_command = {step_key: {}}
-                if not isinstance(command[step_key], dict):
-                    break
                 for group_type, groups in six.iteritems(command[step_key]):
                     if len(groups) > max_groups:
-                        maybe_split = True
                         command[step_key][group_type], new_command[step_key][group_type] = \
                             groups[0:max_groups], groups[max_groups:]
                 if new_command[step_key]:
-                    split_commands.append(new_command)
+                    new_commands.append(new_command)
                     command = new_command
+                    maybe_split = True
                 else:
                     break
-            new_commands += split_commands
-        self.commands = new_commands
+            split_commands += new_commands
+        self.commands = split_commands
         return maybe_split
 
 

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -44,6 +44,17 @@ class RoleTypes(Enum):
     productAdmin = 2
 
 
+class ActionVerbTypes(Enum):
+    add = 1
+    addAdobeID = 2
+    addRoles = 3
+    createEnterpriseID = 4
+    remove = 5
+    removeFromOrg = 6
+    removeRoles = 7
+    update = 8
+
+
 class IfAlreadyExistsOptions(Enum):
     ignoreIfAlreadyExists = 1
     updateIfAlreadyExists = 2
@@ -321,6 +332,10 @@ class UserAction(Action):
         for command in self.commands:
             do_split = False
             for verb, verb_commands in six.iteritems(command):
+                foo = ActionVerbTypes
+                bar = GroupTypes
+                if verb not in [ActionVerbTypes.add.name, ActionVerbTypes.remove.name, ActionVerbTypes.addRoles.name]:
+                    continue
                 for group_type, groups in six.iteritems(verb_commands):
                     if len(groups) > max_groups:
                         do_split = True

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -332,8 +332,6 @@ class UserAction(Action):
         for command in self.commands:
             do_split = False
             for verb, verb_commands in six.iteritems(command):
-                foo = ActionVerbTypes
-                bar = GroupTypes
                 if verb not in [ActionVerbTypes.add.name, ActionVerbTypes.remove.name, ActionVerbTypes.addRoles.name]:
                     continue
                 for group_type, groups in six.iteritems(verb_commands):

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -309,6 +309,14 @@ class UserAction(Action):
         return None
 
     def split_groups(self, index, verb, group_type, max_groups):
+        """
+        Split a long list of groups in an add/remove command
+        :param index: index of command to split
+        :param verb: add or remove
+        :param group_type: group type - product, productConfiguration or usergroup
+        :param max_groups: max size of groups (if group list is larger than max it will be split)
+        :return:
+        """
         if index > len(self.commands):
             raise ArgumentError(six.text_type("Index {} not found in commands list").format(index))
         if verb not in self.commands[index]:

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -20,7 +20,6 @@
 
 import re
 import six
-import copy
 from enum import Enum
 
 from .api import Action, QuerySingle, QueryMultiple
@@ -332,6 +331,7 @@ class UserAction(Action):
         for command in self.commands:
             step_key, step_args = next(six.iteritems(command))
             if step_key not in [StepKeys.add.name, StepKeys.remove.name, StepKeys.addRoles.name]:
+                new_commands.append(command)
                 continue
             split_commands = self._split_groups(step_key, command, max_groups)
             if len(split_commands) > 1:

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -308,6 +308,24 @@ class UserAction(Action):
         self.append(removeFromDomain={})
         return None
 
+    def split_groups(self, index, verb, group_type, max_groups):
+        if index > len(self.commands):
+            raise ArgumentError(six.text_type("Index {} not found in commands list").format(index))
+        if verb not in self.commands[index]:
+            raise ArgumentError(six.text_type("'{}' not specified in command").format(verb))
+        if group_type not in self.commands[index][verb]:
+            raise ArgumentError(six.text_type("'{}' not specified in command").format(group_type))
+        groups = self.commands[index][verb][group_type]
+        if len(groups) > max_groups:
+            updated_index = False
+            while len(groups) >= 1:
+                batch, groups = groups[0:max_groups], groups[max_groups:]
+                if not updated_index:
+                    self.commands[index][verb][group_type] = batch
+                    updated_index = True
+                else:
+                    self.commands.append({verb: {group_type: batch}})
+
 
 class UsersQuery(QueryMultiple):
     """


### PR DESCRIPTION
The objective of this fix is to split up large lists of groups to add and/or remove - the UMAPI imposes a limit of 10 per list in a single command.

I say "per list" because a command can contain multiple lists of groups.  

```
do: [
  { <- single command
   add: {
     product: [p1, p2, p3, .... ] <- 10 group limit
     usergroup: [g1, g2, g3 .... ] <- 10 group limit
   },
   remove: {
     product: [n1, n2, n3 .... ] <- 10 group limit
   }
 }
]
```

If any of the group lists in the above example have more than 10 groups, the umapi client will split that list into groups of 10.  The first group will be updated on the existing command (with respect to the add/remove container and group type).  Additional group lists will be added to new commands, which will be appended to the command list.

For example - if there are 15 user groups to be added in the above example, then the command list would look like this after the split:

```
do: [
  {
   add: {
     product: [p1, p2, p3, .... ]
     usergroup: [g1, g2 ... g10 ] <- First 10 groups are assigned here
   },
   remove: {
     product: [n1, n2, n3 .... ]
   }
  },
   add: {
     usergroup: [g11 .. g15 ] <- next group (up to 10) goes in a new command
   },
 }
]
```

If the initial example had more than 10 adds AND 10 removes, then the split would create one command per "add/remove" verb per 10-group list.

The process that checks group length and splits group lists happens in `Connection.execute_multiple()`.  I considered putting it in the add/remove functions of UserAction, but decided against it - I wasn't sure how best to provide the max group limit.  The connection class already manages the actions-per-call and commands-per-action limits, so it seemed like a more natural fit.  I'm open to feedback on my approach.