### PR TITLE
Ssl verify

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: python
 python:
 - 2.7
-- 3.4
 - 3.5
 - 3.6
+- 3.7
+- 3.8
 install:
 - pip install --upgrade pip setuptools wheel
 - pip install -r requirements.txt

--- a/docs/usage-instructions-v2.md
+++ b/docs/usage-instructions-v2.md
@@ -135,6 +135,29 @@ for group in groups:
     print(group)
 ```
 
+## Disabling SSL Verification
+
+In environments where SSL inspection is enforced at the firewall, the UMAPI client can encounter the following error:
+
+2017-07-07 09:01:37 4916 CRITICAL main - UMAPI connection to org id 'someUUIDvalue@AdobeOrg' failed: [SSL: CERTIFICATE_VERIFY_FAILED] 
+
+This is because the requests module is not aware of the middle-man certificate required for SSL inspection.  The recommended solution to this problem is to specify a path to the certificate bundle using the  REQUESTS_CA_BUNDLE environment variable (see https://helpx.adobe.com/enterprise/kb/UMAPI-UST.html for details).  However, in some cases following these steps does not solve the problem.  The next logical step is to disable SSL inspection on the firewall for the UMAPI traffic.  If, however, this is not permitted, you may work around the issue by disabling SSL verification for user-sync.  
+
+Disabling the verification is unsafe, and leaves the umapi client vulnerable to middle man attacks, so it is recommended to  avoid disabling it if at all possible.  The umapi client only ever targets two URLs - the usermanagement endpoint and the ims endpoint - both of which are secure Adobe URL's.  In addition, since this option is only recommended for use in a secure network environment, any potential risk is further mitigated.
+
+To bypass the ssl verification, update the umapi config as follows:
+
+```yaml
+server:
+  ssl_verify: False
+```
+
+During the calls, you will also see  a warning from requests:
+
+"InsecureRequestWarning: Unverified HTTPS request is being made to host 'usermanagement-stage.adobe.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
+  InsecureRequestWarning"
+
+
 # Performing Operations on Users
 
 User operations in the UMAPI are performed in three steps:

--- a/docs/usage-instructions-v2.md
+++ b/docs/usage-instructions-v2.md
@@ -145,11 +145,14 @@ This is because the requests module is not aware of the middle-man certificate r
 
 Disabling the verification is unsafe, and leaves the umapi client vulnerable to middle man attacks, so it is recommended to  avoid disabling it if at all possible.  The umapi client only ever targets two URLs - the usermanagement endpoint and the ims endpoint - both of which are secure Adobe URL's.  In addition, since this option is only recommended for use in a secure network environment, any potential risk is further mitigated.
 
-To bypass the ssl verification, update the umapi config as follows:
+To bypass the SSL verification, construct the Connection object using `ssl_verify=False` argument (set the True by default).  Borrowing from the initial example,
 
-```yaml
-server:
-  ssl_verify: False
+```python
+conn = umapi_client.Connection(
+                               org_id=config["org_id"],
+                               auth_dict=config,
+                               ssl_verify=False
+                               )
 ```
 
 During the calls, you will also see  a warning from requests:

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -53,6 +53,7 @@ class Connection:
                  retry_max_attempts=4,
                  retry_first_delay=15,
                  retry_random_delay=5,
+                 ssl_verify=True,
                  timeout_seconds=120.0,
                  throttle_actions=10,
                  throttle_commands=10,
@@ -182,7 +183,8 @@ class Connection:
         if remote:
             components = urlparse.urlparse(self.endpoint)
             try:
-                result = self.session.get(components[0] + "://" + components[1] + "/status", timeout=self.timeout)
+                result = self.session.get(components[0] + "://" + components[1] + "/status", timeout=self.timeout,
+                                          verify=self.ssl_verify)
             except Exception as e:
                 if self.logger: self.logger.debug("Failed to connect to server for status: %s", e)
                 result = None
@@ -421,14 +423,17 @@ class Connection:
         if body:
             request_body = json.dumps(body)
             def call():
-                return self.session.post(self.endpoint + path, auth=self.auth, data=request_body, timeout=self.timeout)
+                return self.session.post(self.endpoint + path, auth=self.auth, data=request_body, timeout=self.timeout,
+                                         verify=self.ssl_verify)
         else:
             if not delete:
                 def call():
-                    return self.session.get(self.endpoint + path, auth=self.auth, timeout=self.timeout)
+                    return self.session.get(self.endpoint + path, auth=self.auth, timeout=self.timeout,
+                                            verify=self.ssl_verify)
             else:
                 def call():
-                    return self.session.delete(self.endpoint + path, auth=self.auth, timeout=self.timeout)
+                    return self.session.delete(self.endpoint + path, auth=self.auth, timeout=self.timeout,
+                                               verify=self.ssl_verify)
 
         start_time = time()
         result = None

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -122,6 +122,7 @@ class Connection:
         self.retry_max_attempts = retry_max_attempts
         self.retry_first_delay = retry_first_delay
         self.retry_random_delay = retry_random_delay
+        self.ssl_verify = ssl_verify
         self.timeout = float(timeout_seconds) if timeout_seconds and float(timeout_seconds) > 0.0 else None
         self.throttle_actions = max(int(throttle_actions), 1)
         self.throttle_commands = max(int(throttle_commands), 1)


### PR DESCRIPTION

Added support for supressing SSL verification.  Sometimes the CA cert bundles do not work as expected.  In such cases, SSL inspection can be disabled - but if this is not allowed, the last resort is to skip the check.  This doesn't represent any real risk since the umapi client only targets two secure adobe domains, but I put in a lengthy description anyway.

I tested this as a last resort with a client today successfully. 

## Disabling SSL Verification

In environments where SSL inspection is enforced at the firewall, the UMAPI client can encounter the following error:

2017-07-07 09:01:37 4916 CRITICAL main - UMAPI connection to org id 'someUUIDvalue@AdobeOrg' failed: [SSL: CERTIFICATE_VERIFY_FAILED] 

This is because the requests module is not aware of the middle-man certificate required for SSL inspection.  The recommended solution to this problem is to specify a path to the certificate bundle using the  REQUESTS_CA_BUNDLE environment variable (see https://helpx.adobe.com/enterprise/kb/UMAPI-UST.html for details).  However, in some cases following these steps does not solve the problem.  The next logical step is to disable SSL inspection on the firewall for the UMAPI traffic.  If, however, this is not permitted, you may work around the issue by disabling SSL verification for user-sync.  

Disabling the verification is unsafe, and leaves the umapi client vulnerable to middle man attacks, so it is recommended to  avoid disabling it if at all possible.  The umapi client only ever targets two URLs - the usermanagement endpoint and the ims endpoint - both of which are secure Adobe URL's.  In addition, since this option is only recommended for use in a secure network environment, any potential risk is further mitigated.

To bypass the ssl verification, update the umapi config as follows:

```yaml
server:
  ssl_verify: False
```

During the calls, you will also see  a warning from requests:

"InsecureRequestWarning: Unverified HTTPS request is being made to host 'usermanagement-stage.adobe.io'. Adding certificate verification is strongly advised. See: https://urllib3.readthedocs.io/en/latest/advanced-usage.html#ssl-warnings
  InsecureRequestWarning"