### PR TITLE
DMESVCS-543 : Umapi log message fix

### DIFF
--- a/tests/test_connections.py
+++ b/tests/test_connections.py
@@ -246,14 +246,13 @@ def test_get_retry_logging(log_stream):
         pytest.raises(UnavailableError, conn.make_call, "")
         stream.flush()
         log = stream.getvalue()  # save as a local so can do pytest -l to see exact log
-        assert log == """UMAPI timeout...service unavailable (code 429 on try 1)
-Next retry in 3 seconds...
-UMAPI timeout...service unavailable (code 429 on try 2)
-Next retry in 3 seconds...
-UMAPI timeout...service unavailable (code 429 on try 3)
+        assert log == """UMAPI request limit reached (code 429 on try 1)
+waiting 3 seconds to continue...
+UMAPI request limit reached (code 429 on try 2)
+waiting 3 seconds to continue...
+UMAPI request limit reached (code 429 on try 3)
 UMAPI timeout...giving up after 3 attempts (6 seconds).
 """
-
 
 # log_stream fixture defined in conftest.py
 def test_post_retry_logging(log_stream):
@@ -266,14 +265,13 @@ def test_post_retry_logging(log_stream):
         pytest.raises(UnavailableError, conn.make_call, "", [3, 5])
         stream.flush()
         log = stream.getvalue()  # save as a local so can do pytest -l to see exact log
-        assert log == """UMAPI timeout...service unavailable (code 429 on try 1)
-Next retry in 3 seconds...
-UMAPI timeout...service unavailable (code 429 on try 2)
-Next retry in 3 seconds...
-UMAPI timeout...service unavailable (code 429 on try 3)
+        assert log == """UMAPI request limit reached (code 429 on try 1)
+waiting 3 seconds to continue...
+UMAPI request limit reached (code 429 on try 2)
+waiting 3 seconds to continue...
+UMAPI request limit reached (code 429 on try 3)
 UMAPI timeout...giving up after 3 attempts (6 seconds).
 """
-
 
 def test_get_server_fail():
     with mock.patch("umapi_client.connection.requests.Session.get") as mock_get:

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -500,7 +500,7 @@ class Connection:
             if checked_result.success:
                 return result
 
-            if self.logger: self.logger.warning("UMAPI timeout...service unavailable (code %s on try %d)",
+            if self.logger: self.logger.warning("UMAPI request limit reached (code %s on try %d)",
                                                 checked_result.status_code, num_attempts)
 
             retry_wait = checked_result.timeout
@@ -511,7 +511,7 @@ class Connection:
 
             if num_attempts < self.retry_max_attempts:
                 if retry_wait > 0:
-                    if self.logger: self.logger.warning("Next retry in %d seconds...", retry_wait)
+                    if self.logger: self.logger.warning(" waiting %d seconds to continue..", retry_wait)
                     sleep(retry_wait)
                 else:
                     if self.logger: self.logger.warning("Immediate retry...")

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -511,7 +511,7 @@ class Connection:
 
             if num_attempts < self.retry_max_attempts:
                 if retry_wait > 0:
-                    if self.logger: self.logger.warning(" waiting %d seconds to continue..", retry_wait)
+                    if self.logger: self.logger.warning("waiting %d seconds to continue...", retry_wait)
                     sleep(retry_wait)
                 else:
                     if self.logger: self.logger.warning("Immediate retry...")


### PR DESCRIPTION


## Summary
* modify Umapi client messaging for throttling
* change the "Timeout" phrasing to match support approved messaging. Instead of Umapi timeout


Fixes #88 
