### PR TITLE
Fix bad return on RequestError

### DIFF
--- a/tests/test_queries.py
+++ b/tests/test_queries.py
@@ -104,7 +104,7 @@ def test_query_multiple_user_not_found():
     with mock.patch("umapi_client.connection.requests.Session.get") as mock_get:
         mock_get.return_value = MockResponse(404, text="404 Object not found")
         conn = Connection(**mock_connection_params)
-        assert conn.query_multiple("user") == ([], True)
+        assert conn.query_multiple("user") == ([], True, 0, 0, 0, 0)
 
 
 def test_query_multiple_user_paged():
@@ -230,7 +230,7 @@ def test_query_multiple_usergroup_not_found():
     with mock.patch("umapi_client.connection.requests.Session.get") as mock_get:
         mock_get.return_value = MockResponse(404, text="404 Object not found")
         conn = Connection(**mock_connection_params)
-        assert conn.query_multiple("user-group") == ([], True)
+        assert conn.query_multiple("user-group") == ([], True, 0, 0, 0, 0)
 
 
 def test_query_multiple_usergroup_paged():

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -308,7 +308,7 @@ class Connection:
             if re.result.status_code == 404:
                 if self.logger: self.logger.debug("Ran %s query: %s %s (0 found)",
                                                   object_type, url_params, query_params)
-                return [], True
+                return [], True, 0, 0, 0, 0
             else:
                 raise re
 


### PR DESCRIPTION
See #91 

I just had to add the missing return values for the return case when the exception was skipped