### PR TITLE
add X-Request-Id in UMAPI GET calls

### DIFF
--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -21,6 +21,7 @@
 import json
 import logging
 import os
+import uuid
 from email.utils import parsedate_tz, mktime_tz
 from platform import python_version, version as platform_version
 from random import randint
@@ -489,6 +490,7 @@ class Connection:
                 self.logger.info("Sending end_sync signal")
                 extra_headers['Pragma'] = 'umapi-sync-end'
                 self.sync_ended = False
+            self.uuid = str(uuid.uuid4())
             request_body = json.dumps(body)
             def call():
                 return self.session.post(self.endpoint + path, auth=self.auth, data=request_body, timeout=self.timeout,
@@ -497,7 +499,7 @@ class Connection:
             if not delete:
                 def call():
                     return self.session.get(self.endpoint + path, auth=self.auth, timeout=self.timeout,
-                                            verify=self.ssl_verify)
+                                            verify=self.ssl_verify, headers=self.uuid)
             else:
                 def call():
                     return self.session.delete(self.endpoint + path, auth=self.auth, timeout=self.timeout,

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -498,7 +498,7 @@ class Connection:
             if not delete:
                 def call():
                     return self.session.get(self.endpoint + path, auth=self.auth, timeout=self.timeout,
-                                            verify=self.ssl_verify, headers={"X-Request-Id": uuid.uuid4()})
+                                            verify=self.ssl_verify, headers={"X-Request-Id": str(uuid.uuid4())})
             else:
                 def call():
                     return self.session.delete(self.endpoint + path, auth=self.auth, timeout=self.timeout,

--- a/umapi_client/connection.py
+++ b/umapi_client/connection.py
@@ -490,7 +490,6 @@ class Connection:
                 self.logger.info("Sending end_sync signal")
                 extra_headers['Pragma'] = 'umapi-sync-end'
                 self.sync_ended = False
-            self.uuid = str(uuid.uuid4())
             request_body = json.dumps(body)
             def call():
                 return self.session.post(self.endpoint + path, auth=self.auth, data=request_body, timeout=self.timeout,
@@ -499,7 +498,7 @@ class Connection:
             if not delete:
                 def call():
                     return self.session.get(self.endpoint + path, auth=self.auth, timeout=self.timeout,
-                                            verify=self.ssl_verify, headers=self.uuid)
+                                            verify=self.ssl_verify, headers={"X-Request-Id": uuid.uuid4()})
             else:
                 def call():
                     return self.session.delete(self.endpoint + path, auth=self.auth, timeout=self.timeout,


### PR DESCRIPTION
<!-- Don't forget to update the PR title to concisely describe the proposed changes -->

## Summary
*  set X-Request-Id in UMAPI GET calls with  uuid.uuid4()

<!-- Document the testing procedure for the PR reviewer. Attach any relevant configuration files and
     document invocation options -->
## Testing Steps
*  when we make GET calls to the UMAPI, we should set the X-Request-Id header to a Universally Unique ID

<!-- if this PR relates to a bug, please link the issue here following this exact syntax -->
Fixes #95 
