### PR TITLE
Update functional.py - fixes #102

### DIFF
--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -110,7 +110,7 @@ class UserAction(Action):
             Action.__init__(self, user=email, useAdobeID=True, **kwargs)
         elif username and '@' in username:
             Action.__init__(self, user=username, **kwargs)
-        elif username and '@' not in username::
+        elif username and '@' not in username:
             Action.__init__(self, user=username, domain=self.domain, **kwargs)
         else:
             Action.__init__(self, user=email, **kwargs)

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -103,13 +103,15 @@ class UserAction(Action):
                 raise ArgumentError("No user identity specified.")
         elif not domain:
             raise ArgumentError("Both username and domain must be specified")
-
-        if username:
-            Action.__init__(self, user=username, domain=self.domain, **kwargs)
-        elif id_type == IdentityTypes.adobeID:
+        
+        if id_type == IdentityTypes.adobeID:
             # by default if two users have the same email address, the UMAPI server will prefer the matching
             # Federated or Enterprise ID user; so we use the undocumented option to prefer the AdobeID match
             Action.__init__(self, user=email, useAdobeID=True, **kwargs)
+        elif username and '@' in username:
+            Action.__init__(self, user=username, **kwargs)
+        elif username and '@' not in username::
+            Action.__init__(self, user=username, domain=self.domain, **kwargs)
         else:
             Action.__init__(self, user=email, **kwargs)
 


### PR DESCRIPTION
**Is your feature request related to a problem? Please describe.**
currently the accounts that should have username different than email and both being an email formatted value, need a 2 step process: create with email == username, then update the username

**Describe the solution you'd like**
The UMAPI allows this type of JSON format:
```
[{"user": "username@domain.com",
 "do": [
    {"createFederatedID": {"email": "some_email@domain.com", 
                           "option": "ignoreIfAlreadyExists", 
                           "firstname": "different", 
                           "lastname": "values", 
                           "country": "GB" }
    }
 ]
}]
```
This creates an account in Admin Console in a single call, no need to chain an 'update' action inside the 'do' statement anymore
The benefit is that you can create accounts in trustee orgs directly without the current problem of creating with username==email.

**Describe alternatives you've considered**
.

**Additional context**
user-sync.py project will also have a PR added to support this create action
