### PR TITLE
remove removeFromDomain action

### DIFF
--- a/tests/test_functional.py
+++ b/tests/test_functional.py
@@ -355,26 +355,11 @@ def test_remove_from_organization_delete_adobeid():
                                 "user": "dbrotsky@adobe.com",
                                 "useAdobeID": True}
 
-
-def test_delete_account_enterpriseid():
-    user = UserAction(id_type=IdentityTypes.enterpriseID, email="dbrotsky@o.on-the-side.net")
-    user.delete_account()
-    assert user.wire_dict() == {"do": [{"removeFromDomain": {}}],
-                                "user": "dbrotsky@o.on-the-side.net"}
-
-
-def test_delete_account_adobeid():
-    user = UserAction(id_type=IdentityTypes.adobeID, email="dbrotsky@adobe.com")
-    with pytest.raises(ValueError):
-        user.delete_account()
-
-
 def test_add_to_products():
     group = UserGroupAction(group_name="SampleUsers")
     group.add_to_products(products=["Photoshop", "Illustrator"])
     assert group.wire_dict() == {"do": [{"add": {"productConfiguration": ["Photoshop", "Illustrator"]}}],
                                  "usergroup": "SampleUsers"}
-
 
 def test_add_to_products_all():
     group = UserGroupAction(group_name="SampleUsers")

--- a/umapi_client/functional.py
+++ b/umapi_client/functional.py
@@ -278,18 +278,6 @@ class UserAction(Action):
         self.append(removeFromOrg={"deleteAccount": True if delete_account else False})
         return None
 
-    def delete_account(self):
-        """
-        Delete a user's account.
-        Deleting the user's account can only be done if the user's domain is controlled by the authorized organization,
-        and removing the account will also remove the user from all organizations with access to that domain.
-        :return: None, because you cannot follow this command with another.
-        """
-        if self.id_type == IdentityTypes.adobeID:
-            raise ArgumentError("You cannot delete an Adobe ID account.")
-        self.append(removeFromDomain={})
-        return None
-
 
 class UsersQuery(QueryMultiple):
     """


### PR DESCRIPTION
removeFromDomain is deprecated and throws errors

removeFromDomain is replaced by removeFromOrg with the boolean flag for deleteAccount